### PR TITLE
Fix OOM Killed issue caused by low memory limit

### DIFF
--- a/sre/roles/observability_tools/tasks/install_elasticsearch.yaml
+++ b/sre/roles/observability_tools/tasks/install_elasticsearch.yaml
@@ -37,6 +37,8 @@
         value_type: raw
       - value: data.persistence.size="32Gi"
         value_type: raw
+      - value: data.resourcesPreset="large"
+        value_type: raw
   tags:
     - install_tools
   when:

--- a/sre/roles/sample_applications/tasks/install_astronomy_shop.yaml
+++ b/sre/roles/sample_applications/tasks/install_astronomy_shop.yaml
@@ -66,6 +66,8 @@
             requests:
               cpu: 10m
               memory: 250Mi
+            limits:
+              memory: 500Mi
         cartService:
           resources:
             requests:
@@ -105,6 +107,8 @@
             requests:
               cpu: 25m
               memory: 300Mi
+            limits:
+              memory: 500Mi
         frontend:
           resources:
             requests:
@@ -122,6 +126,8 @@
             requests:
               cpu: 25m
               memory: 550Mi
+            limits:
+              memory: 700Mi
         loadgenerator:
           imageOverride:
             repository: quay.io/it-bench/loadgenerator
@@ -154,6 +160,8 @@
             requests:
               cpu: 50m
               memory: 100Mi
+            limits:
+              memory: 700Mi
         shippingService:
           resources:
             requests: 


### PR DESCRIPTION
Some pods often get killed due to out of memory, and enter a CrashLoopBackOff loop.  This affects the deployment because the script would be waiting for all pods getting ready.